### PR TITLE
Certbot automatization of certs renewal

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -119,6 +119,36 @@ common_open_ports:
   - "443"
 ```
 
+### Автоматическое выписывание сертификатов
+
+Есть два вида челленджа: HTTP и DNS, первый не тестировался, проверен второй. 
+Для этого используется сервис certbot и пара кастомных скриптов. Для того, чтобы активировать, в
+`group_vars/marzban/marzban.yml` выставьте конфиги в модуле Automatic Certificate management:
+
+```yaml
+### Automatic Certificate Management ###
+# Enable automatic certificate generation and renewal (true/false)
+marzban_auto_cert: true
+marzban_cert_challenge_method: "dns" # ["http, only if we can proof"]
+
+# Email for Let's Encrypt registration
+marzban_cert_email: "<email for acme registration>"
+
+# Staging environment (true for testing, false for production)
+marzban_cert_staging: false
+
+# Certificate domains to obtain
+marzban_cert_domains:
+  - "{{ marzban_domain }}"
+  - "*.{{ marzban_domain }}"
+
+marzban_cert_dns_provider: "cloudns"
+marzban_cert_dns_credentials:
+  cloudns_auth_id: "<cloudns-auth-id>"
+  cloudns_auth_password: "<cloudns-auth-pwd>"
+marzban_cert_renewal_interval: "43200"  # 12 hours
+```
+
 ## Хватит уже, бегом к делу
 
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,37 @@ common_open_ports:
   - "443"
 ```
 
+### Automatic certificate signing
+
+For proof of owning domain, there's two domains: DNS and HTTP [untested]
+For purposes of automatic cert signing we use certbot service. To activate this option, change in
+`group_vars/marzban/marzban.yml` lines under `Automatic Certificate Management` section:
+
+```yaml
+### Automatic Certificate Management ###
+# Enable automatic certificate generation and renewal (true/false)
+marzban_auto_cert: true
+marzban_cert_challenge_method: "dns" # ["http, only if we can proof"]
+
+# Email for Let's Encrypt registration
+marzban_cert_email: "<email for acme registration>"
+
+# Staging environment (true for testing, false for production)
+marzban_cert_staging: false
+
+# Certificate domains to obtain
+marzban_cert_domains:
+  - "{{ marzban_domain }}"
+  - "*.{{ marzban_domain }}"
+
+marzban_cert_dns_provider: "cloudns"
+marzban_cert_dns_credentials:
+  cloudns_auth_id: "<cloudns-auth-id>"
+  cloudns_auth_password: "<cloudns-auth-pwd>"
+marzban_cert_renewal_interval: "43200"  # 12 hours
+```
+
+
 ## I'm tired wait, go go go
 
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -15,9 +15,10 @@ inventory_ignore_extensions = ~, .orig, .bak, .cfg, .retry, .pyc, .pyo, .creds
 log_path = $HOME/ansible/ansible.log
 # Set "false" for hidden skipped tasks and hosts
 display_skipped_hosts = true
-remote_user = ubuntu
+
+remote_user = root
 ### Add custom key if used
-#private_key_file = /Users/v.kamerdinerov/.ssh/some-custom-key
+private_key_file = <path-to-key>
 any_errors_fatal = true
 
 [inventory]
@@ -27,4 +28,4 @@ ignore_patterns = artifacts, credentials
 retries = 6
 pipelining = True
 timeout = 60
-ssh_args = -o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=5m -o ConnectionAttempts=5 -o PreferredAuthentications=publickey
+ssh_args = -o UserKnownHostsFile=/home/<user>/.ssh/known_hosts -o ControlMaster=auto -o ControlPersist=5m -o ConnectionAttempts=5 -o PreferredAuthentications=publickey

--- a/group_vars/marzban/marzban.yml
+++ b/group_vars/marzban/marzban.yml
@@ -1,18 +1,18 @@
 ---
 
 # Main domain for the Marzban panel/reality
-marzban_domain: example-domain.com
+marzban_domain: "your-domain.example"
 
 # Subdomain for Marzban control panel access (Full path: {{ panel_path }}.{{ marzban_domain }})
 marzban_panel_uri: "panel.{{ marzban_domain }}"
 
 # SNI for traffic masking
-marzban_sni: "awesome.sni"
+marzban_sni: "masking-domain.example"
 
 # Login credentials for panel access
 marzban_panel_login: "admin"
 # Password must not contain symbols like ^$
-marzban_panel_password: "panelpassword"
+marzban_panel_password: "ultradmin"
 
 # Port for VLESS Reality TCP connections
 marzban_vless_tcp_reality_port: "12000"
@@ -25,10 +25,10 @@ marzban_api_ports:
   - "62051"
 
 # Use Cloudflare WARP for outbound traffic (true/false)
-marzban_warp: false
+marzban_warp: true
 
 # Enable API documentation (available at /docs and /redoc)
-marzban_docs: false
+marzban_docs: true
 
 # Use MySQL(maria-db) instance instead of SQLite (true/false)
 marzban_mysql_instance: true
@@ -36,12 +36,12 @@ marzban_mysql_instance: true
 # Enable automatic backup (true/false)
 marzban_backup: true
 # Backup schedule (cron format)
-marzban_backup_cron: { minute: "0", hour: "2", day: "*", month: "*", weekday: "*" }
+marzban_backup_cron: { minute: "0", hour: "3", day: "1,10,20", month: "*", weekday: "*" }
 
 # Telegram bot token for backup notifications (leave empty if not needed)
-marzban_backup_telegram_bot_token: ""
+marzban_backup_telegram_bot_token: "token-bot-bkp"
 # Telegram chat ID for backup notifications (auto-detected if empty; initiate chat with the bot first)
-marzban_backup_telegram_chat_id: ""
+marzban_backup_telegram_chat_id: "your-tg-id"
 
 # Use custom template for subscription page  for placing various clients regarding different operating systems and tutorials related to them
 marzban_custom_subscription_template: true
@@ -62,6 +62,24 @@ marzban_direct_domains:
   - "domain:captive.apple.com"
   - "full:detectportal.firefox.com"
   - "domain:networkcheck.kde.org"
+  - "domain:gosuslugi.ru"
+  - "domain:vk.com"
+  - "domain:vk-portal.net"
+  - "domain:vkuseraudio.com"
+  - "domain:ozon.ru"
+  - "domain:userapi.com"
+  - "domain:mycdn.me"
+  - "domain:mradx.net"
+  - "domain:mail.ru"
+  - "domain:okcdn.ru"
+  - "domain:dzen.ru"
+  - "domain:dzeninfra.ru"
+  - "domain:consentmanager.net"
+  - "domain:yandex.net"
+  - "domain:yandex.ru"
+  - "domain:imgsmail.ru"
+  - "domain:yastatic.net"
+  - "domain:yadro.ru"
 
 # Cloudflare WARP traffic filtering settings
 marzban_warp_domains:
@@ -85,60 +103,48 @@ common_additional_packages:
   - "vnstat"
   - "git"
 
+### Automatic Certificate Management ###
+# Enable automatic certificate generation and renewal (true/false)
+marzban_auto_cert: true
+
+# Certificate challenge method: "http" or "dns"
+# http: Uses HTTP-01 challenge (for single domain)
+# dns: Uses DNS-01 challenge (supports wildcards, requires DNS provider API)
+# DNS provider settings (for DNS-01 challenge)
+marzban_cert_challenge_method: "dns" # ["http, only if we can proof"]
+
+# Email for Let's Encrypt registration
+marzban_cert_email: "<email for acme registration>"
+
+# Staging environment (true for testing, false for production)
+marzban_cert_staging: false
+
+# Certificate domains to obtain
+marzban_cert_domains:
+  - "{{ marzban_domain }}"
+  - "*.{{ marzban_domain }}"
+
+marzban_cert_dns_provider: "cloudns"
+marzban_cert_dns_credentials:
+  cloudns_auth_id: "<cloudns-auth-id>"
+  cloudns_auth_password: "<cloudns-auth-pwd>"
+# dns_cloudns_sub_auth_id
+
+# marzban_cert_dns_provider: [cloudflare, amazon, route53, digital_ocean]
+# > dns_cloudflare_api_token | [dns_cloudflare_email, dns_cloudflare_api_key]
+# > dns_digitalocean_token
+# > [dns_route53_access_key_id, dns_route53_secret_access_key]
+# Certificate renewal settings
+marzban_cert_renewal_interval: "43200"  # 12 hours
+
+
 ### SSL Configuration ###
 # Certificate and key names must be in the format: {{ some_cool_name }}.cert and {{ some_cool_name }}.key
 # Certificates will be used in marzban_ssl_certfile and marzban_ssl_keyfile
 # Certificates should cover both the domain {{ marzban_domain }} and its wildcard *.{{ marzban_domain }}
+# fallback option
 vault_ssl_certs:
-  example-domain.com.cert: |
-    -----BEGIN CERTIFICATE-----
-    MIIDvDCCAqSgAwIBAgIUNQJEwM4oJdv2Xq2V9tFRDtVUfXMwDQYJKoZIhvcNAQEL
-    BQAwbDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcM
-    DVNhbiBGcmFuY2lzY28xEzARBgNVBAoMCk15IENvbXBhbnkxGzAZBgNVBAMMEmV4
-    YW1wbGUtZG9tYWluLmNvbTAeFw0yNDA3MjkxMDM5NDNaFw0yNTA3MjkxMDM5NDNa
-    MGwxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1T
-    YW4gRnJhbmNpc2NvMRMwEQYDVQQKDApNeSBDb21wYW55MRswGQYDVQQDDBJleGFt
-    cGxlLWRvbWFpbi5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDO
-    95w59NWVA4sRIx3cpE3S/iQyxR+VPXflvH7ygsYZJDZA+5UO90KWwgyWMQ9WpOKH
-    LmsYRbL1SWaSCWbMzTt3W8xnitEhxF2OchDQfFjOo1JpgZK+t41caLO/2f50hHTJ
-    mWEx5N0dc1yJ/Q3AoZn8ErHAtgz6GZdutKYo4bCnkuXYFPWcXhyoE85Mbi6AGOEA
-    RBD2ID9DM52FpCauZyM4/hwLVEUmM+odiT/pAHM9n+QD51m6jZRBrorWrcMrVZhA
-    MM1c/wMLpw42nR60vjAPcDrU6497TARYeZGcpkRaqjr7tO/q0COlJb/4RhhHnMJA
-    wFZR4cMFpL4TeZfnEdTPAgMBAAGjVjBUMDMGA1UdEQQsMCqCEmV4YW1wbGUtZG9t
-    YWluLmNvbYIUKi5leGFtcGxlLWRvbWFpbi5jb20wHQYDVR0OBBYEFM1vY7s8LWgK
-    Vq3Gh8yuNGyldx+qMA0GCSqGSIb3DQEBCwUAA4IBAQBSJeB/u5eZkUH33V60xKk3
-    MuLtScx19IMdIQlKdJxFqKcUHNJZCr2Qel2JBzrnVJhkGmGGveuDuzDF6X8xlUoJ
-    EAnwj6fp8ejJ0rY8Qmlxp+MnzciHmfUi2jA7OP57I2LP+Ln5YC5O5TEBBz2wT37s
-    b96k+hE/OGadfoooTEIaVe7BXPRpigZ1qBVvMs/Cmp0lIPULCCajZMclFUVNuoEg
-    6tDXGyLXAf4QvZSdNeKFXFfTS2SjOWpzjn5v/U7v8xHk7nROkxWBR9KSRFNsRjCf
-    q45juslAHwAu0Z9+W4LaNsKwe0ixRyEzGPW0lhCPQScL3FvRfFiaZ18zKbrwURl8
-    -----END CERTIFICATE-----
-  example-domain.com.key: |
-    -----BEGIN PRIVATE KEY-----
-    MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDO95w59NWVA4sR
-    Ix3cpE3S/iQyxR+VPXflvH7ygsYZJDZA+5UO90KWwgyWMQ9WpOKHLmsYRbL1SWaS
-    CWbMzTt3W8xnitEhxF2OchDQfFjOo1JpgZK+t41caLO/2f50hHTJmWEx5N0dc1yJ
-    /Q3AoZn8ErHAtgz6GZdutKYo4bCnkuXYFPWcXhyoE85Mbi6AGOEARBD2ID9DM52F
-    pCauZyM4/hwLVEUmM+odiT/pAHM9n+QD51m6jZRBrorWrcMrVZhAMM1c/wMLpw42
-    nR60vjAPcDrU6497TARYeZGcpkRaqjr7tO/q0COlJb/4RhhHnMJAwFZR4cMFpL4T
-    eZfnEdTPAgMBAAECggEAOChSkR1ASMcl2FgNdb11Sm9f9hCrsax0mHcNgRL/2nmL
-    aRV6jA2GWW68yJH2Rf3GY4SyVWswFEM+3BhF9wMnBAt6CoxNk5p7AjgsHM3osOT6
-    6xrX7PzUFANq5n8pfockQ0FlcIrXfnK7ZMuvjBmtNQsDhTVAjyobf1PwE/6tFsKV
-    hwnTMerIo48PoPOoH0Uh/iIZrycVMfr46W44BMnUsNn1Ft+N6GNnQlY6zt6bnYHj
-    pDg1QTzyPDH8apOXuqo2SGn8FZoO+RVAS2CXtJWQjVd8UDi1PLDoY7DBi6WLI8oh
-    wKITsPJvVNQjm2lEanIyR9PqcfDnc2YRiaPEpLvdwQKBgQD1EkrWGUQaOZDoGy05
-    jTUkmj/j7UVggMAON7FuaLQ6i3LVamE0uI/DcFkIc6lsMYWgDbqhOM1Z9DPDXVzq
-    q/gUWeelYooRrv0TL7Ohfqt16mPrkiuVKeX5l5A507kWzpvONNoZrniQ7nUUQ/DX
-    t7L9YrpU4g7jsSNmVTil2NzODwKBgQDYMlMOYI7rh5Yqb/Hp3zpam9BAZNBbHrp9
-    xXaamgT5f0l4yZSit0I/bWJ4uqxTORVY13odbMBM1BhWJ0sgQj1vIZnykTnUv14+
-    enqfepD3GXc/1uaRPeHrgVfUhZ2p6S5poJ0lAuDAEKNKV6UhwispDp9DbHqRWyYX
-    77M9aYlNQQKBgENZ2p1KZk/6wBs51Mz7RL6hcauXOrjRyXZe0fFw7w8j4dRLHxnZ
-    GxFwH9fVyZsFZR7ehwrlzHHLTiqDzxRjXJNjPelS0nUXrU+HjYt1f3OxjfJgwn+E
-    +0ID6EwsJrLg5yrdlY73RwU1s5F1NoxiXNuMNX88fTEQLpViGGZj2hL7AoGBAJKv
-    wm600QO5YQe2IJsf3IXxxiCKxlusw7fmLIzFB68I0B7mFrU4RfinDPMBJT7qMjOv
-    L6mbSfZWyZRa4LwodWpbkApmwqg4l4cort5Z2NXvL1vfQV02cXzKq38EkW7hSZ5d
-    XYHpK/jk0QX15ZK8HXCj/SdQCPFquLPw7No0KvaBAoGBANVasKlGnbLVm0Ogqq69
-    HpwCZDg6kSPCAhxrNhzxQ2+upA03hcqocQQDaIAukehmJiychRmAzLEJ9dTHch10
-    kI0b1uYAryNT6JtiomUB0CRd3y3Ljx+Zvs/HV3YIjh/eara4EHm9cp7qzE52Rll0
-    WsxP7hG9NsXQ9gItY9bLoILa
-    -----END PRIVATE KEY-----
+  your-domain.example.cert: |
+    <fullchain.pem>
+  your-domain.example.key: |
+    <privkey.pem>

--- a/hosts.yml
+++ b/hosts.yml
@@ -1,0 +1,24 @@
+---
+all:
+  children:
+    marzban:
+      children:
+        marzban_main:
+          hosts:
+            main:
+              ansible_host: <your-panel-ip>
+              ansible_port: <your-panel-port>
+              marzban_roles:
+                - panel
+        marzban_nodes:
+          hosts:
+            node1:
+              ansible_host: <node-1-ip>
+              ansible_port: <node-1-port>
+              marzban_roles:
+                - node
+            node2:
+              ansible_host: <node-2-ip>
+              ansible_port: <node-2-port>
+              marzban_roles:
+                - node

--- a/roles/marzban/defaults/main.yml
+++ b/roles/marzban/defaults/main.yml
@@ -11,18 +11,21 @@ marzban_node_dirs:
   - base_dir: "/opt/marzban-node"
   - work_dir: "/var/lib/marzban-node"
 
-marzban_ssl_certfile: "{{ vault_ssl_certs.keys() | select('search', 'cert') | list | first }}"
-marzban_ssl_keyfile: "{{ vault_ssl_certs.keys() | select('search', 'key') | list | first }}"
+# SSL Configuration - automatically determined based on marzban_auto_cert
+marzban_ssl_certfile: "{% if marzban_auto_cert is defined and marzban_auto_cert %}{{ marzban_domain }}.cert{% else %}{{ vault_ssl_certs.keys() | select('search', 'cert') | list | first }}{% endif %}"
+marzban_ssl_keyfile: "{% if marzban_auto_cert is defined and marzban_auto_cert %}{{ marzban_domain }}.key{% else %}{{ vault_ssl_certs.keys() | select('search', 'key') | list | first }}{% endif %}"
 marzban_ssl_ca_type: "public"
 
 marzban_image: "gozargah/marzban"
 marzban_image_tag: "latest"
 
 marzban_haproxy_image: "haproxy"
-marzban_haproxy_image_tag: "2.4.28"
+marzban_haproxy_image_tag: "2.4.29"
 marzban_haproxy_dirs:
   - etc_dir: "/etc/haproxy"
 
+marzban_access_logs_file: "{{ marzban_system_dirs | json_query('[*].work_dir') | first }}/access.log"
+marzban_errors_logs_file: "{{ marzban_system_dirs | json_query('[*].work_dir') | first }}/error.log"
 
 ### Panel configuration
 
@@ -70,6 +73,15 @@ marzban_panel_host_info:
     address: "{{ marzban_domain }}"
     port: 443
 
+### Automatic Certificate Management ###
+marzban_auto_cert: false
+marzban_cert_challenge_method: "http"
+marzban_cert_email: ""
+marzban_cert_staging: false
+marzban_cert_domains: []
+marzban_cert_dns_provider: ""
+marzban_cert_dns_credentials: {}
+marzban_cert_renewal_interval: "43200"  # 12 hours
 
 ### WARP configuration
 marzban_warp: false
@@ -116,3 +128,16 @@ marzban_nodes_host_info: ""
 
 marzban_node_image: "gozargah/marzban-node"
 marzban_node_image_tag: "latest"
+
+### Logrotate
+marzban_rsyslog_logrotate:
+  - name: marzban
+    log_files:
+      - "{{ marzban_access_logs_file }}"
+      - "{{ marzban_errors_logs_file }}"
+    keep: 7
+    frequency: daily
+    missingok: true
+    notifempty: true
+    compress: true
+    copytruncate: true

--- a/roles/marzban/tasks/conf/node.yml
+++ b/roles/marzban/tasks/conf/node.yml
@@ -20,6 +20,8 @@
     mode: "{{ item.mode }}"
   loop:
     - {src: docker-compose-node.yml.j2, dst: docker-compose.yml, mode: "0644"}
+    - {src: certbot-exec.sh.j2, dst: certbot-exec.sh, mode: "0755"}
+    - {src: certbot-creds.sh.j2, dst: certbot-creds.sh, mode: "0755"}
     - {src: env-node.j2, dst: .env, mode: "0644"}
   tags: config
 

--- a/roles/marzban/tasks/conf/panel.yml
+++ b/roles/marzban/tasks/conf/panel.yml
@@ -18,6 +18,8 @@
     mode: "{{ item.mode }}"
   loop:
     - {src: docker-compose.yml.j2, dst: docker-compose.yml, mode: "0644"}
+    - {src: certbot-exec.sh.j2, dst: certbot-exec.sh, mode: "0755"}
+    - {src: certbot-creds.sh.j2, dst: certbot-creds.sh, mode: "0755"}
     - {src: env.j2, dst: .env, mode: "0644"}
 
 - name: "Marzban | Configure {{ role | upper() }} | Generate private key if not exist"
@@ -102,6 +104,65 @@
     content: "{{ item.value }}"
   no_log: true
   loop: "{{ vault_ssl_certs | dict2items }}"
+  when: 
+    - marzban_auto_cert is not defined or not marzban_auto_cert
+    - vault_ssl_certs is defined
+
+- name: "Marzban | Configure {{ role | upper() }} | Debug DNS credentials"
+  debug:
+    msg: |
+      DNS Credentials Debug Info:
+      - Provider: {{ marzban_cert_dns_provider }}
+      - Credentials defined: {{ marzban_cert_dns_credentials is defined }}
+      - Credentials content: {{ marzban_cert_dns_credentials | to_nice_json }}
+      - Expected environment variables will be:
+      {% for key, value in marzban_cert_dns_credentials.items() %}
+      - {{ key | upper }}={{ value if value else '(EMPTY VALUE!)' }}
+      {% endfor %}
+  when: 
+    - marzban_auto_cert is defined and marzban_auto_cert
+    - marzban_cert_challenge_method == "dns"
+    - marzban_cert_dns_credentials is defined
+
+- name: "Marzban | Configure {{ role | upper() }} | Validate certificate configuration"
+  assert:
+    that:
+      - marzban_cert_domains is defined and marzban_cert_domains | length > 0
+      - marzban_cert_challenge_method in ["http", "dns"]
+    fail_msg: |
+      Certificate configuration is incomplete. Please ensure:
+      - marzban_cert_domains contains at least one domain
+      - marzban_cert_challenge_method is either "http" or "dns"
+      Note: marzban_cert_email will use a default if not set, but it's recommended to set a real email
+    success_msg: "Certificate configuration is valid"
+  when: marzban_auto_cert is defined and marzban_auto_cert
+
+- name: "Marzban | Configure {{ role | upper() }} | Validate DNS provider configuration"
+  assert:
+    that:
+      - marzban_cert_dns_provider is defined and marzban_cert_dns_provider != ""
+      - marzban_cert_dns_credentials is defined and marzban_cert_dns_credentials | length > 0
+    fail_msg: |
+      DNS provider configuration is incomplete. Please ensure:
+      - marzban_cert_dns_provider is set (e.g., 'cloudns', 'cloudflare')
+      - marzban_cert_dns_credentials contains the required credentials
+    success_msg: "DNS provider configuration is valid"
+  when: 
+    - marzban_auto_cert is defined and marzban_auto_cert
+    - marzban_cert_challenge_method == "dns"
+
+- name: "Marzban | Configure {{ role | upper() }} | Show certificate configuration"
+  debug:
+    msg: |
+      Certificate Configuration:
+      - Domain: {{ marzban_domain }}
+      - Email: {{ marzban_cert_email if marzban_cert_email else 'default email will be used' }}
+      - Challenge Method: {{ marzban_cert_challenge_method | default('http') }}
+      - Staging: {{ marzban_cert_staging | default(false) }}
+      - Domains: {{ marzban_cert_domains | default([]) | join(', ') }}
+      - DNS Provider: {{ marzban_cert_dns_provider if marzban_cert_dns_provider else 'none' }}
+      - Renewal Interval: {{ marzban_cert_renewal_interval | default('43200') }} seconds
+  when: marzban_auto_cert is defined and marzban_auto_cert
 
 - name: "Marzban | Configure {{ role | upper() }} | Create and start services"
   community.docker.docker_compose_v2:
@@ -112,7 +173,7 @@
   ansible.builtin.debug:
     var: startup_output
 
-- name: "Marzban | Configure {{ role | upper() }} | Get ADMIN token"
+- name: "Marzban | Configure {{ role | upper() }} | Wait for marzban to be ready"
   uri:
     url: "https://{{ marzban_panel_uri }}/api/admin/token"
     method: POST
@@ -128,8 +189,9 @@
       client_secret: ""
     body_format: form-urlencoded
     return_content: true
-  retries: 8
-  delay: 5
+    validate_certs: false  # Allow self-signed certificates during initial setup
+  retries: 20
+  delay: 15
   register: token_data
   until: token_data is not failed
   tags: bootstrap
@@ -144,6 +206,7 @@
       Content-Type: "application/json"
     body_format: json
     return_content: true
+    validate_certs: false
   retries: 8
   delay: 5
   register: panel_hosts_info
@@ -162,12 +225,12 @@
       VLESS TCP REALITY: "{{ marzban_panel_host_info }}"
     body_format: json
     return_content: true
+    validate_certs: false
   retries: 8
   delay: 5
   register: panel_host_info_change
   until: panel_host_info_change is not failed
   tags: bootstrap
-
 
 - name: "Marzban | Configure {{ role | upper() }} | Backup"
   include_tasks: ../backup.yml

--- a/roles/marzban/templates/certbot-creds.sh.j2
+++ b/roles/marzban/templates/certbot-creds.sh.j2
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+echo 'Creating DNS credentials file...'
+mkdir -p /secrets
+
+{% if marzban_cert_dns_provider == "cloudflare" %}
+    {% if marzban_cert_dns_credentials.cloudflare_api_token is defined %}
+printf 'dns_cloudflare_api_token=%s\n' "$CLOUDFLARE_API_TOKEN" > /secrets/cloudflare.ini
+    {% else %}
+printf 'dns_cloudflare_email=%s\n' "$CLOUDFLARE_EMAIL" > /secrets/cloudflare.ini
+printf 'dns_cloudflare_api_key=%s\n' "$CLOUDFLARE_API_KEY" >> /secrets/cloudflare.ini
+    {% endif %}
+chmod 600 /secrets/cloudflare.ini
+echo 'Cloudflare credentials file created'
+{% elif marzban_cert_dns_provider == "cloudns" %}
+printf 'dns_cloudns_auth_id=%s\n' "$CLOUDNS_AUTH_ID" > /secrets/cloudns.ini
+    {% if marzban_cert_dns_credentials.cloudns_auth_password is defined %}
+printf 'dns_cloudns_auth_password=%s\n' "$CLOUDNS_AUTH_PASSWORD" >> /secrets/cloudns.ini
+{% endif %}
+    {% if marzban_cert_dns_credentials.cloudns_sub_auth_id is defined %}
+printf 'dns_cloudns_sub_auth_id=%s\n' "$CLOUDNS_SUB_AUTH_ID" >> /secrets/cloudns.ini
+{% endif %}
+
+chmod 600 /secrets/cloudns.ini
+echo 'ClouDNS credentials file created'
+{% elif marzban_cert_dns_provider == "route53" %}
+printf 'dns_route53_access_key_id=%s\n' "$AWS_ACCESS_KEY_ID" > /secrets/route53.ini
+printf 'dns_route53_secret_access_key=%s\n' "$AWS_SECRET_ACCESS_KEY" >> /secrets/route53.ini
+chmod 600 /secrets/route53.ini
+echo 'Route53 credentials file created'
+{% elif marzban_cert_dns_provider == "digitalocean" %}
+printf 'dns_digitalocean_token=%s\n' "$DIGITALOCEAN_TOKEN" > /secrets/digitalocean.ini
+chmod 600 /secrets/digitalocean.ini
+echo 'DigitalOcean credentials file created'
+{% endif %}
+
+echo 'DNS credentials file created successfully'
+cat /secrets/{{ marzban_cert_dns_provider }}.ini

--- a/roles/marzban/templates/certbot-exec.sh.j2
+++ b/roles/marzban/templates/certbot-exec.sh.j2
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Install DNS provider plugins if needed
+{% if marzban_cert_dns_provider == "cloudns" %}
+pip install certbot-dns-cloudns
+{% elif marzban_cert_dns_provider == "cloudflare" %}
+pip install certbot-dns-cloudflare
+{% elif marzban_cert_dns_provider == "route53" %}
+pip install certbot-dns-route53
+{% elif marzban_cert_dns_provider == "digitalocean" %}
+pip install certbot-dns-digitalocean
+{% endif %}
+
+while :; do
+  echo 'Starting certificate check...'
+  
+  # Create domain directories if they don't exist
+  mkdir -p /etc/letsencrypt/live/{{ marzban_domain }}
+  
+  # Check if certificates exist and are valid
+  if [ ! -f /etc/letsencrypt/live/{{ marzban_domain }}/fullchain.pem ] || 
+     [ ! -f /etc/letsencrypt/live/{{ marzban_domain }}/privkey.pem ] ||
+     ! openssl x509 -checkend 2592000 -noout -in /etc/letsencrypt/live/{{ marzban_domain }}/fullchain.pem >/dev/null 2>&1; then
+    
+    echo 'Certificates missing or expiring, obtaining new ones...'
+    
+{% if marzban_cert_challenge_method == "http" %}
+    certbot certonly --webroot -w /var/www/certbot \
+      $STAGING \
+      --email $EMAIL \
+      --agree-tos\
+      --no-eff-email \
+      --keep-until-expiring \
+      --cert-name {{ marzban_domain }} \
+{% for domain in marzban_cert_domains %}
+      -d {{ domain }} \
+{% endfor %}
+{% elif marzban_cert_challenge_method == "dns" %}
+    certbot certonly \
+      --authenticator dns-{{ marzban_cert_dns_provider }} \
+      --dns-{{ marzban_cert_dns_provider }}-credentials /etc/letsencrypt/secrets/{{ marzban_cert_dns_provider }}.ini \
+      $STAGING \
+      --email $EMAIL \
+      --keep-until-expiring \
+      --cert-name {{ marzban_domain }} \
+{% for domain in marzban_cert_domains %}
+      -d {{ domain }} \
+{% endfor %}
+      --agree-tos
+{% endif %}
+    
+    if [ $? -eq 0 ]; then
+      echo 'Certificate obtained successfully'
+      # Copy certificates to shared directory with proper naming
+      cp /etc/letsencrypt/live/{{ marzban_domain }}/fullchain.pem /etc/letsencrypt/live/{{ marzban_domain }}/{{ marzban_domain }}.cert
+      cp /etc/letsencrypt/live/{{ marzban_domain }}/privkey.pem /etc/letsencrypt/live/{{ marzban_domain }}/{{ marzban_domain }}.key
+      
+      # Set proper permissions
+      chmod 644 /etc/letsencrypt/live/{{ marzban_domain }}/{{ marzban_domain }}.cert
+      chmod 600 /etc/letsencrypt/live/{{ marzban_domain }}/{{ marzban_domain }}.key
+      
+      echo 'Certificates copied and permissions set'
+      
+      # Signal HAProxy to reload (optional - HAProxy can detect file changes)
+      pkill -HUP haproxy 2>/dev/null || true
+    else
+      echo 'Certificate generation failed'
+    fi
+  else
+    echo 'Certificates are valid, skipping renewal'
+  fi
+  
+  echo 'Sleeping for' $RENEWAL_INTERVAL 'seconds...'
+  sleep $RENEWAL_INTERVAL
+done

--- a/roles/marzban/templates/docker-compose-node.yml.j2
+++ b/roles/marzban/templates/docker-compose-node.yml.j2
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   haproxy:
     image: {{ marzban_haproxy_image }}:{{ marzban_haproxy_image_tag }}
@@ -7,9 +9,46 @@ services:
     volumes:
       - {{ marzban_haproxy_dirs | json_query('[*].etc_dir') | first }}/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
       - {{ marzban_system_dirs | json_query('[*].work_dir') | first }}:/var/lib/marzban
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+      - certbot_webroot:/var/www/certbot:ro
+{% endif %}
       - /etc/localtime:/etc/localtime:ro
     depends_on:
       - marzban-node
+{% if marzban_auto_cert is defined and marzban_auto_cert and inventory_hostname + '.' + marzban_domain != marzban_panel_uri %}
+      - certbot
+{% endif %}
+
+{% if marzban_auto_cert is defined and marzban_auto_cert and inventory_hostname + '.' + marzban_domain != marzban_panel_uri %}
+  certbot:
+    image: certbot/certbot:latest
+    restart: unless-stopped
+    volumes:
+      - ./certbot-exec.sh:/tmp/certbot-exec.sh
+      - certbot_conf:/etc/letsencrypt
+      - certbot_webroot:/var/www/certbot
+      - {{ marzban_system_dirs | json_query('[*].work_dir') | first }}/certs:/etc/letsencrypt/live/{{ marzban_domain }}:rw
+      - /etc/localtime:/etc/localtime:ro
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+      - certbot_secrets:/etc/letsencrypt/secrets:ro
+{% endif %}
+    entrypoint: ["/tmp/certbot-exec.sh"]
+    env_file: .env
+
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+    depends_on:
+      - certbot-dns-credentials
+
+  certbot-dns-credentials:
+    env_file: .env
+    image: alpine:latest
+    restart: "no"
+    volumes:
+      - certbot_secrets:/secrets
+      - ./certbot-creds.sh:/tmp/certbot-creds.sh
+    entrypoint: ["/tmp/certbot-creds.sh"]
+{% endif %}
+{% endif %}
 
   marzban-node:
     image: {{ marzban_node_image }}:{{ marzban_node_image_tag }}
@@ -22,3 +61,15 @@ services:
     ports:
       - {{ marzban_api_ports[0] }}:62050
       - {{ marzban_api_ports[1] }}:62051
+
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+volumes:
+  certbot_conf:
+    name: certbot_conf_{{ inventory_hostname }}
+  certbot_webroot:
+    name: certbot_webroot_{{ inventory_hostname }}
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+  certbot_secrets:
+    name: certbot_secrets_{{ inventory_hostname }}
+{% endif %}
+{% endif %}

--- a/roles/marzban/templates/docker-compose.yml.j2
+++ b/roles/marzban/templates/docker-compose.yml.j2
@@ -9,9 +9,46 @@ services:
     volumes:
       - {{ marzban_haproxy_dirs | json_query('[*].etc_dir') | first }}/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
       - {{ marzban_system_dirs | json_query('[*].work_dir') | first }}:/var/lib/marzban
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+      - certbot_webroot:/var/www/certbot:ro
+{% endif %}
       - /etc/localtime:/etc/localtime:ro
     depends_on:
       - marzban
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+      - certbot
+{% endif %}
+
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+  certbot:
+    image: certbot/certbot:latest
+    restart: unless-stopped
+    volumes:
+      - ./certbot-exec.sh:/tmp/certbot-exec.sh
+      - certbot_conf:/etc/letsencrypt
+      - certbot_webroot:/var/www/certbot
+      - {{ marzban_system_dirs | json_query('[*].work_dir') | first }}/certs:/etc/letsencrypt/live/{{ marzban_domain }}:rw
+      - /etc/localtime:/etc/localtime:ro
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+      - certbot_secrets:/etc/letsencrypt/secrets:ro
+{% endif %}
+    entrypoint: ["/tmp/certbot-exec.sh"]
+    env_file: .env
+
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+    depends_on:
+      - certbot-dns-credentials
+
+  certbot-dns-credentials:
+    env_file: .env
+    image: alpine:latest
+    restart: "no"
+    volumes:
+      - certbot_secrets:/secrets
+      - ./certbot-creds.sh:/tmp/certbot-creds.sh
+    entrypoint: ["/tmp/certbot-creds.sh"]
+{% endif %}
+{% endif %}
 
   marzban:
     image: {{ marzban_image }}:{{ marzban_image_tag }}
@@ -49,8 +86,20 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+{% endif %}
 
 volumes:
+{% if marzban_mysql_instance is defined and marzban_mysql_instance %}
   mariadb_data:
     name: mariadb_data
+{% endif %}
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+  certbot_conf:
+    name: certbot_conf
+  certbot_webroot:
+    name: certbot_webroot
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+  certbot_secrets:
+    name: certbot_secrets
+{% endif %}
 {% endif %}

--- a/roles/marzban/templates/env.j2
+++ b/roles/marzban/templates/env.j2
@@ -9,8 +9,13 @@ MARIADB_PASSWORD={{ marzban_mysql_user_password }}
 SQLALCHEMY_DATABASE_URL = "sqlite:////var/lib/marzban/db.sqlite3"
 {% endif %}
 UVICORN_PORT = {{ marzban_panel_port }}
+{% if marzban_auto_cert is defined and marzban_auto_cert %}
+UVICORN_SSL_CERTFILE = "/var/lib/marzban/certs/{{ marzban_domain }}.cert"
+UVICORN_SSL_KEYFILE = "/var/lib/marzban/certs/{{ marzban_domain }}.key"
+{% else %}
 UVICORN_SSL_CERTFILE = "/var/lib/marzban/certs/{{ marzban_ssl_certfile }}"
 UVICORN_SSL_KEYFILE = "/var/lib/marzban/certs/{{ marzban_ssl_keyfile }}"
+{% endif %}
 UVICORN_SSL_CA_TYPE = "{{ marzban_ssl_ca_type }}"
 XRAY_SUBSCRIPTION_URL_PREFIX = https://{{ marzban_panel_uri }}
 CUSTOM_TEMPLATES_DIRECTORY="{{ marzban_system_dirs | json_query('[*].templates_dir') | first }}/"
@@ -27,3 +32,21 @@ DOCS: True
 TELEGRAM_BOT_TOKEN={{ marzban_backup_telegram_bot_token }}
 TELEGRAM_CHAT_ID={{ marzban_backup_telegram_chat_id }}
 {% endif %}
+
+
+{% for key, value in marzban_cert_dns_credentials.items() %}
+{{ key | upper }}={{ value }}
+{% endfor %}
+
+DOMAINS={{ marzban_cert_domains | join(',') }}
+EMAIL={{ marzban_cert_email }}
+CHALLENGE_METHOD={{ marzban_cert_challenge_method }}
+{% if marzban_cert_staging is defined and marzban_cert_staging %}
+STAGING=--staging
+{% else %}
+STAGING=
+{% endif %}
+{% if marzban_cert_dns_provider is defined and marzban_cert_challenge_method == "dns" %}
+DNS_PROVIDER={{ marzban_cert_dns_provider }}
+{% endif %}
+RENEWAL_INTERVAL={{ marzban_cert_renewal_interval }}

--- a/roles/marzban/templates/haproxy.cfg.j2
+++ b/roles/marzban/templates/haproxy.cfg.j2
@@ -6,14 +6,22 @@ global
 defaults
   mode tcp
   option tcplog
-  timeout client 30s
-  timeout connect 4s
-  timeout server 30s
   option dontlognull
+  timeout client 30s
+  timeout client-fin 30s
+  timeout connect 30s
+  timeout server 30s
+  timeout tunnel 1h
+  timeout http-request 20s
 
 frontend http_frontend
   bind *:80
   mode http
+{% if marzban_auto_cert is defined and marzban_auto_cert and marzban_cert_challenge_method == "http" %}
+  # ACME challenge handling
+  acl is_acme_challenge path_beg /.well-known/acme-challenge/
+  use_backend acme_challenge if is_acme_challenge
+{% endif %}
   http-response set-header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload;"
   http-response set-header X-Content-Type-Options "nosniff"
   http-response set-header X-XSS-Protection "1; mode=block"
@@ -25,6 +33,15 @@ frontend http_frontend
   option httplog
   option http-keep-alive
 
+{% if marzban_auto_cert is defined and marzban_auto_cert and marzban_cert_challenge_method == "http" %}
+backend acme_challenge
+  mode http
+  server acme_server 127.0.0.1:8080 check
+  # Alternative: serve from file system
+  # http-request set-path /var/www/certbot%[path]
+  # errorfile 503 /var/www/certbot/.well-known/acme-challenge/
+{% endif %}
+
 frontend https_frontend
   bind *:443 alpn h2,http/1.1
   tcp-request inspect-delay 5s
@@ -32,9 +49,11 @@ frontend https_frontend
 {% if 'panel' in role %}
   use_backend panel if { req.ssl_sni -m end {{ marzban_panel_uri }} }
 {% endif %}
+{% if inventory_hostname is defined and inventory_hostname != 'main' %}
+  use_backend panel if { req.ssl_sni -m end {{ inventory_hostname }}.{{ marzban_domain }} }
+{% endif %}
   use_backend reality if { req.ssl_sni -m end {{ marzban_sni }} }
   log global
-
 
 {% if 'panel' in role %}
 backend panel

--- a/roles/marzban/templates/xray_config.json.j2
+++ b/roles/marzban/templates/xray_config.json.j2
@@ -83,13 +83,6 @@
 {% endfor %}
               ],
               "type": "field"
-            },
-            {
-                "protocol": [
-                    "bittorrent"
-                ],
-                "outboundTag": "BLOCK",
-                "type": "field"
             }
 {% if marzban_warp is defined and marzban_warp %}
             ,{

--- a/roles/marzban/vars/main.yml
+++ b/roles/marzban/vars/main.yml
@@ -21,10 +21,12 @@ marzban_warp_packages_state: present
 marzban_warp_package_name: "cloudflare-warp"
 marzban_warp_packages:
   - "{{ marzban_warp_package_name }}={{ marzban_warp_pkg_version }}"
-marzban_warp_pkg_version: "2024.6.497-1"
+marzban_warp_pkg_version: "2025.2.600.0"
 
 marzban_warp_deb_install: true
-marzban_warp_deb_package: "{{ marzban_warp_repo_url }}/pool/{{ ansible_distribution_release }}/{{ marzban_warp_apt_release_channel }}/c/cloudflare-warp/cloudflare-warp_{{ marzban_warp_pkg_version }}_amd64.deb"
+  # marzban_warp_deb_package: "{{ marzban_warp_repo_url }}/pool/{{ ansible_distribution_release }}/{{ marzban_warp_apt_release_channel }}/c/cloudflare-warp/cloudflare-warp_{{ marzban_warp_pkg_version }}_amd64.deb"
+
+marzban_warp_deb_package: "https://downloads.cloudflareclient.com/v1/download/{{ ansible_distribution_release }}-intel/version/{{ marzban_warp_pkg_version }}"
 
 
 marzban_cli_script_url: "https://github.com/Gozargah/Marzban-scripts/raw/master/marzban.sh"


### PR DESCRIPTION
Signing and renewal of certs using certbot service

Changes for usage described in both `README.md`
Not tested against `http` challenge

In structure:
- added two service in docker-compose jinja templates
- added fields to reflect DNS credentials
- added special scripts for corresponding docker-compose services

I'm not really DevOps guy, so don't know how linting and things do work in ansible, but needed that feature because I hate manual fetching keys, and last time I couldn't fetch configs from subscription to my friend 